### PR TITLE
Generate Benchmark for EverWatch

### DIFF
--- a/geobench_v2/generate_benchmark/cloudsen12.py
+++ b/geobench_v2/generate_benchmark/cloudsen12.py
@@ -66,14 +66,16 @@ def create_subset(root: str, save_dir: str) -> None:
             )
             & (metadata_df["label_type"] == "high")
         ].reset_index(drop=True)
-        
+
         tacoreader.compile(
             dataframe=metadata_df,
             output=os.path.join(save_dir, f"geobench_cloudsen12-{key}.taco"),
             nworkers=4,
         )
 
-        test_taco = tacoreader.load(os.path.join(save_dir, f"geobench_cloudsen12-{key}.taco"))
+        test_taco = tacoreader.load(
+            os.path.join(save_dir, f"geobench_cloudsen12-{key}.taco")
+        )
 
         meta_dfs.append(metadata_df)
 

--- a/geobench_v2/generate_benchmark/everwatch.py
+++ b/geobench_v2/generate_benchmark/everwatch.py
@@ -12,6 +12,7 @@ from geobench_v2.generate_benchmark.object_detection_util import (
     compare_resize,
     resize_object_detection_dataset,
 )
+import numpy as np
 
 
 def create_subset(metadata_df: pd.DataFrame, save_dir: str) -> None:
@@ -30,17 +31,174 @@ def create_subset(metadata_df: pd.DataFrame, save_dir: str) -> None:
     pass
 
 
-def generate_metadata_df(root) -> pd.DataFrame:
-    """Generate metadata DataFrame for EverWatch dataset."""
+def generate_metadata_df(root: str) -> pd.DataFrame:
+    """Generate metadata DataFrame for EverWatch dataset with geolocation from colonies.geojson.
+
+    Args:
+        root: Root directory for EverWatch dataset
+
+    Returns:
+        DataFrame with annotations and geo-information
+    """
+    import json
+    import re
+    from shapely.geometry import shape, Point
+
+    # Load annotations
     annot_df_train = pd.read_csv(os.path.join(root, "train.csv"))
     annot_df_train["split"] = "train"
     annot_df_test = pd.read_csv(os.path.join(root, "test.csv"))
     annot_df_test["split"] = "test"
     annot_df = pd.concat([annot_df_train, annot_df_test], ignore_index=True)
 
+    # Filter out invalid boxes
     annot_df = annot_df[
         (annot_df["xmin"] != annot_df["xmax"]) & (annot_df["ymin"] != annot_df["ymax"])
     ].reset_index(drop=True)
+
+    # Load colonies GeoJSON
+    with open(os.path.join(root, "colonies.geojson"), "r") as f:
+        colony_data = json.load(f)
+
+    # Create dictionary mapping colony names to their geometries and centroid coordinates
+    colony_dict = {}
+    for feature in colony_data["features"]:
+        name = feature["properties"]["Name"].lower()
+        geom = shape(feature["geometry"])
+        centroid = geom.centroid
+        colony_dict[name] = {"geometry": geom, "lon": centroid.x, "lat": centroid.y}
+
+    # Function to match image names to colony names
+    def match_colony(image_name):
+        """Match image names to colony names in geojson.
+
+        Handles both named colonies (e.g., "horus_04_27_2022_361.png")
+        and numeric filenames (e.g., "46552351.png").
+
+        Args:
+            image_name: Image filename to match
+
+        Returns:
+            Colony name or None if no match found
+        """
+        # Convert to lowercase and remove file extension
+        basename = os.path.splitext(image_name.lower())[0]
+
+        # Try direct match with colony names
+        for colony_name in colony_dict:
+            if basename.startswith(colony_name):
+                return colony_name
+
+        # Try pattern matching for common variations
+        pattern_mappings = {
+            "3bramp": "3b_boat_ramp",
+            "6thbridge": "6th_bridge",
+            "jupiter": "jupiter",
+            "juno": "juno",
+            "shamash": "shamash",
+            "jetport": "jetport",
+            "horus": "horus",
+            "lostmans": "lostmans_creek",
+        }
+
+        for pattern, colony in pattern_mappings.items():
+            if pattern in basename:
+                return colony
+
+        # For numeric-only filenames, map the prefix to colony names
+        numeric_colonies = {
+            "10": "10",
+            "1351": "1351",
+            "1573": "1573",
+            "1824": "1824",
+            "1844": "1844",
+            "1882": "1882",
+            "1888": "1888",
+            "2282": "2282",
+            "2307": "2307",
+            "2309": "2309",
+            "2418": "2418",
+            "2419": "2419",
+            "2647": "2647",
+            "2968": "2968",
+            "3134": "3134",
+            "3235": "3235",
+            "3702": "3702",
+        }
+
+        # For numeric prefixes like '52928xxx'
+        for prefix, colony in numeric_colonies.items():
+            if basename.startswith(prefix):
+                return colony
+
+        # For exact numeric matches (when the entire filename without extension matches a colony)
+        if basename in numeric_colonies:
+            return numeric_colonies[basename]
+
+        return None
+
+    # Create a set of unique image names
+    unique_images = set(annot_df["image_path"])
+
+    # Create a mapping of image to colony
+    image_to_colony = {}
+    images_without_match = []
+
+    for img in unique_images:
+        colony = match_colony(img)
+        if colony:
+            image_to_colony[img] = colony
+        else:
+            images_without_match.append(img)
+
+    if images_without_match:
+        print(
+            f"Warning: Could not match {len(images_without_match)} images to colony names."
+        )
+        print("First 5 unmatched images:", images_without_match[:5])
+
+    # Add colony information to the annotations DataFrame
+    def get_colony_info(img_name):
+        colony = image_to_colony.get(img_name)
+        if colony:
+            return pd.Series(
+                {
+                    "colony_name": colony,
+                    "lon": colony_dict[colony]["lon"],
+                    "lat": colony_dict[colony]["lat"],
+                }
+            )
+        return pd.Series({"colony_name": None, "lon": None, "lat": None})
+
+    # Apply the function to add colony information
+    colony_info = annot_df["image_path"].apply(get_colony_info)
+    annot_df = pd.concat([annot_df, colony_info], axis=1)
+
+    # Create validation split - stratify by colony if possible
+    train_indices = annot_df[annot_df["split"] == "train"].index
+
+    # Use colony_name for stratification if available, otherwise use a simpler approach
+    if annot_df["colony_name"].notna().all():
+        from sklearn.model_selection import train_test_split
+
+        train_idx, val_idx = train_test_split(
+            train_indices,
+            test_size=0.1,
+            random_state=42,
+            stratify=annot_df.loc[train_indices, "colony_name"],
+        )
+        annot_df.loc[val_idx, "split"] = "val"
+    else:
+        # Simple approach: take 20% of training data for validation
+        val_size = int(len(train_indices) * 0.1)
+        val_indices = np.random.choice(train_indices, val_size, replace=False)
+        annot_df.loc[val_indices, "split"] = "val"
+
+    print(f"Split counts: {annot_df['split'].value_counts().to_dict()}")
+    print(
+        f"Colonies matched: {annot_df['colony_name'].notna().sum()} of {len(annot_df)} annotations"
+    )
+
     return annot_df
 
 
@@ -70,7 +228,6 @@ def main():
     metadata_df.to_parquet(path)
 
     # metadata_df = metadata_df.iloc[:10]
-
     resize_object_detection_dataset(
         args.root, metadata_df, args.save_dir, target_size=512
     )

--- a/geobench_v2/generate_benchmark/object_detection_util.py
+++ b/geobench_v2/generate_benchmark/object_detection_util.py
@@ -1,0 +1,103 @@
+import os
+import pandas as pd
+import numpy as np
+from PIL import Image
+import matplotlib.pyplot as plt
+import matplotlib.patches as patches
+from tqdm import tqdm
+import argparse
+from pathlib import Path
+
+
+
+def resize_object_detection_dataset(
+    image_dir, annotations_df, output_dir, target_size=512
+):
+    """Resize all images in the dataset to a target size and adapt annotations.
+
+    Args:
+        image_dir (str): Directory containing original images
+        annotations_df (pd.DataFrame): DataFrame with annotations
+        output_dir (str): Directory to save resized images and annotations
+        target_size (int): Target size for both width and height
+    """
+    os.makedirs(os.path.join(output_dir, "images"), exist_ok=True)
+
+    unique_images = annotations_df["image_path"].unique()
+    resized_annotations = []
+    corrupted_images = []
+
+    for img_name in tqdm(unique_images, desc="Resizing images"):
+        image_path = os.path.join(image_dir, img_name)
+        if not os.path.exists(image_path):
+            print(f"Warning: Image {image_path} not found, skipping.")
+            continue
+
+        try:
+            # Open the image with PIL with error handling for truncated files
+            from PIL import ImageFile
+
+            ImageFile.LOAD_TRUNCATED_IMAGES = True 
+
+            img = Image.open(image_path)
+            # Force load to identify potential issues early
+            img.load()
+
+            orig_width, orig_height = img.size
+            img_resized = img.resize(
+                (target_size, target_size), Image.Resampling.LANCZOS
+            )
+
+            output_path = os.path.join(output_dir, "images", img_name)
+            os.makedirs(os.path.dirname(output_path), exist_ok=True)
+            img_resized.save(output_path)
+
+            scale_x = target_size / orig_width
+            scale_y = target_size / orig_height
+
+            img_annotations = annotations_df[annotations_df["image_path"] == img_name]
+            for _, ann in img_annotations.iterrows():
+                xmin_scaled = int(ann["xmin"] * scale_x)
+                ymin_scaled = int(ann["ymin"] * scale_y)
+                xmax_scaled = int(ann["xmax"] * scale_x)
+                ymax_scaled = int(ann["ymax"] * scale_y)
+
+                if (xmax_scaled - xmin_scaled < 3) or (ymax_scaled - ymin_scaled < 3):
+                    continue
+
+                resized_annotations.append(
+                    {
+                        "image_path": img_name,
+                        "label": ann["label"],
+                        "xmin": xmin_scaled,
+                        "ymin": ymin_scaled,
+                        "xmax": xmax_scaled,
+                        "ymax": ymax_scaled,
+                        "split": ann["split"] if "split" in ann else "unknown",
+                    }
+                )
+        except (OSError, IOError, SyntaxError) as e:
+            print(f"Error processing image {image_path}: {str(e)}")
+            corrupted_images.append(img_name)
+            continue
+
+    resized_df = pd.DataFrame(resized_annotations)
+    resized_df.to_csv(os.path.join(output_dir, "resized_annotations.csv"), index=False)
+
+    # Save a list of corrupted images for reference
+    if corrupted_images:
+        with open(os.path.join(output_dir, "corrupted_images.txt"), "w") as f:
+            for img_name in corrupted_images:
+                f.write(f"{img_name}\n")
+        print(
+            f"Warning: {len(corrupted_images)} corrupted images found. List saved to corrupted_images.txt"
+        )
+
+    print(
+        f"Resized {len(unique_images) - len(corrupted_images)} images to {target_size}x{target_size}"
+    )
+    print(
+        f"Created {len(resized_df)} annotations across {len(resized_df['image_path'].unique())} images"
+    )
+    return resized_df
+

--- a/tests/datamodules/test_everwatch.py
+++ b/tests/datamodules/test_everwatch.py
@@ -5,7 +5,7 @@ from geobench_v2.datamodules import GeoBenchEverWatchDataModule
 @pytest.fixture
 def data_root():
     """Path to test data directory."""
-    return "/mnt/rg_climate_benchmark/data/datasets_object_detection/EverWatch"
+    return "/mnt/rg_climate_benchmark/data/geobenchV2/everwatch"
 
 
 @pytest.fixture


### PR DESCRIPTION
The EverWatch bird object detection dataset comes with predetermined train/test split but no validation split. No geospatial data is available.

The native images are 1500x1500 pixels so an idea could be to pass a window of 750x750 and then resize to 512x512 to create more reasonably sized images.

@recursix @naomi-simumba @paolofraccaro 