### PR TITLE
fix stacked images for pastis

### DIFF
--- a/geobench_v2/datasets/pastis.py
+++ b/geobench_v2/datasets/pastis.py
@@ -253,7 +253,7 @@ class GeoBenchPASTIS(GeoBenchBaseDataset):
                     ),
                     "mask": sample["mask"],
                 }
- 
+
             if self.num_time_steps == 1:
                 sample["image"] = sample["image"].squeeze(1)
 


### PR DESCRIPTION
When instance segmentation and return stacked images were on, we were removing the labels and bboxes. It should be OK now.